### PR TITLE
Test scripts get properly parsed JSON body

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2200,6 +2200,19 @@ export default {
         body: this.response.body,
         headers: this.response.headers,
       }
+
+      // Parse JSON body
+      if (
+        syntheticResponse.headers["content-type"] &&
+        isJSONContentType(syntheticResponse.headers["content-type"])
+      ) {
+        try {
+          syntheticResponse.body = JSON.parse(
+            new TextDecoder("utf-8").decode(new Uint8Array(syntheticResponse.body))
+          )
+        } catch (_e) {}
+      }
+
       const { testResults } = runTestScriptWithVariables(this.testScript, {
         response: syntheticResponse,
       })


### PR DESCRIPTION
Test scripts now get properly parsed to the `pw.response.body` field if it is a valid JSON body.

This PR intends to fix #1036 