### PR TITLE
Added link to Demo PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@
 
 _Customized themes are synced with local session storage_
 
-🔥 **PWA**: Install as a [PWA](https://developers.google.com/web/progressive-web-apps) on your device.
+🔥 **PWA**: [Install as a PWA](https://postwoman.io/) on your device. [[More Info](https://developers.google.com/web/progressive-web-apps)]
 
 **Features:**
 


### PR DESCRIPTION
The **'Install as a PWA'** directs the user to docs for pwa. I have shifted the link to a 'More Info'.
And, have linked the Install as a PWA to your PWA.

This _will_ greatly help people who come to the repo, finding how to install it (I saw some issues asking for the same).
I believe a plus will be that user can directly get up running, instead of cloning the repo first

_I read the contribution guidelines, about creating an issue first, but this was very minor, so i directly submitted a PR, maybe if its not suitable, it can directly be closed_