### PR TITLE
Report Extension Version in the settings page

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -260,6 +260,8 @@
   "empty": "Empty",
   "extensions": "Extensions",
   "extensions_use_toggle": "Use the browser extension to send requests (if present)",
+  "extension_version": "Extension Version",
+  "extension_ver_not_reported": "Not Reported",
   "extensions_info1": "Browser extension that simplifies access to Postwoman",
   "extensions_info2": "Get Postwoman browser extension!",
   "installed": "Installed",

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -129,6 +129,15 @@
           </div>
         </li>
       </ul>
+      <ul class="info">
+        <li v-if="extensionVersion != null">
+          Extension Verison: v{{ extensionVersion.major }}.{{ extensionVersion.minor }}
+        </li>
+
+        <li v-else>
+          Extension Verison: Not Reported
+        </li>
+      </ul>
     </pw-section>
 
     <pw-section class="blue" :label="$t('proxy')" ref="proxy">
@@ -210,6 +219,7 @@
 <script>
 import firebase from "firebase/app"
 import { fb } from "~/helpers/fb"
+import { hasExtensionInstalled } from "../helpers/strategies/ExtensionStrategy"
 
 export default {
   components: {
@@ -298,6 +308,10 @@ export default {
           vibrant: false,
         },
       ],
+
+      extensionVersion: hasExtensionInstalled()
+        ? window.__POSTWOMAN_EXTENSION_HOOK__.getVersion()
+        : null,
 
       settings: {
         SCROLL_INTO_ENABLED:

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -131,12 +131,10 @@
       </ul>
       <ul class="info">
         <li v-if="extensionVersion != null">
-          Extension Verison: v{{ extensionVersion.major }}.{{ extensionVersion.minor }}
+          {{ $t("extension_version") }}: v{{ extensionVersion.major }}.{{ extensionVersion.minor }}
         </li>
 
-        <li v-else>
-          Extension Verison: Not Reported
-        </li>
+        <li v-else>{{ $t("extension_version") }}: {{ $t("extension_ver_not_reported") }}</li>
       </ul>
     </pw-section>
 


### PR DESCRIPTION
This PR intends to add text which reports the installed extension version (if present). Really useful for debugging purposes.

There are new translation entries in this PR.