### PR TITLE
Fixed broken tick icons placement in Settings

### DIFF
--- a/components/settings/swatch.vue
+++ b/components/settings/swatch.vue
@@ -14,6 +14,7 @@
 .color {
   display: inline-flex;
   align-items: center;
+  position: relative;
   justify-content: center;
   margin: 8px;
   padding: 16px;
@@ -36,6 +37,11 @@
 
   .activeTick {
     position: absolute;
+    margin: auto;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
   }
 }
 </style>


### PR DESCRIPTION
Hi,

I have added a few CSS to fix the broken placement of Tick Icons in Settings.

This PR fixes #1057 

**Below are the changes, I have implemented:**

CSS for the parent element of tick icon:
```CSS
   position:relative
```

CSS for the tick icon to place it in the center:
 ```CSS
   position:absolute;
   margin: auto;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
```

![image](https://user-images.githubusercontent.com/19655674/89845888-59227400-db9d-11ea-9c05-ffd89bc15978.png)
